### PR TITLE
Renamed 'Providers' references to 'Formatters' to remove confusion

### DIFF
--- a/samples/autofac/Cash.Autofac.Sample.Web/App_Start/CashConfig.cs
+++ b/samples/autofac/Cash.Autofac.Sample.Web/App_Start/CashConfig.cs
@@ -10,7 +10,7 @@ namespace Cash.Autofac.Sample.Web.App_Start
         {
             var registrationService = new CacheKeyRegistrationService();
 
-            registrationService.AddTypedCacheKeyProvider<UserModel>(x => $"{x.Id}");
+            registrationService.RegisterCacheKeyFormatter<UserModel>(x => $"{x.Id}");
 
             return registrationService;
         }

--- a/samples/ninject/Cash.Ninject.Sample.Web/App_Start/CashConfig.cs
+++ b/samples/ninject/Cash.Ninject.Sample.Web/App_Start/CashConfig.cs
@@ -9,7 +9,7 @@ namespace Cash.Ninject.Sample.Web.App_Start
         {
             var registrationService = new CacheKeyRegistrationService();
 
-            registrationService.AddTypedCacheKeyProvider<UserModel>(x => $"{x.Id}");
+            registrationService.RegisterCacheKeyFormatter<UserModel>(x => $"{x.Id}");
 
             return registrationService;
         }

--- a/src/Cash.Core.Tests/Services/CacheKeyGenerationServiceTests.cs
+++ b/src/Cash.Core.Tests/Services/CacheKeyGenerationServiceTests.cs
@@ -76,8 +76,8 @@ namespace Cash.Core.Tests.Services
         [TestMethod]
         public void GetArgumentCacheKey_CreatesProperKey_ForUserDefinedType()
         {
-            A.CallTo(() => CacheKeyRegistrationService.GetTypedCacheKeyProvider<TestModelDefinition>()).Returns(x => $"{x.Id}");
-            A.CallTo(() => CacheKeyRegistrationService.IsProviderRegistered(typeof(TestModelDefinition))).Returns(true);
+            A.CallTo(() => CacheKeyRegistrationService.GetCacheKeyFormatter<TestModelDefinition>()).Returns(x => $"{x.Id}");
+            A.CallTo(() => CacheKeyRegistrationService.IsFormatterRegistered(typeof(TestModelDefinition))).Returns(true);
 
             var model = new TestModelDefinition { Id = 100 };
             var result = CacheKeyGenerationService.GetArgumentsCacheKey(new object[] { model });
@@ -88,8 +88,8 @@ namespace Cash.Core.Tests.Services
         [TestMethod]
         public void GetArgumentCacheKey_CreatesProperKey_ForMultipleUserDefinedType()
         {
-            A.CallTo(() => CacheKeyRegistrationService.GetTypedCacheKeyProvider<TestModelDefinition>()).Returns(x => $"{x.Id}");
-            A.CallTo(() => CacheKeyRegistrationService.IsProviderRegistered(typeof(TestModelDefinition))).Returns(true);
+            A.CallTo(() => CacheKeyRegistrationService.GetCacheKeyFormatter<TestModelDefinition>()).Returns(x => $"{x.Id}");
+            A.CallTo(() => CacheKeyRegistrationService.IsFormatterRegistered(typeof(TestModelDefinition))).Returns(true);
 
             var model1 = new TestModelDefinition { Id = 100 };
             var model2 = new TestModelDefinition { Id = 500 };
@@ -102,8 +102,8 @@ namespace Cash.Core.Tests.Services
         [ExpectedException(typeof(UnregisteredCacheTypeException))]
         public void GetArgumentCacheKey_ThrowsAnException_WhenACacheKeyProviderHasNotBeenRegistered()
         {
-            A.CallTo(() => CacheKeyRegistrationService.GetTypedCacheKeyProvider<TestModelDefinition>()).Throws(new UnregisteredCacheTypeException(typeof(TestModelDefinition)));
-            A.CallTo(() => CacheKeyRegistrationService.IsProviderRegistered(typeof(TestModelDefinition))).Returns(true);
+            A.CallTo(() => CacheKeyRegistrationService.GetCacheKeyFormatter<TestModelDefinition>()).Throws(new UnregisteredCacheTypeException(typeof(TestModelDefinition)));
+            A.CallTo(() => CacheKeyRegistrationService.IsFormatterRegistered(typeof(TestModelDefinition))).Returns(true);
 
             var model = new TestModelDefinition { Id = 100 };
             var result = CacheKeyGenerationService.GetArgumentsCacheKey(new object[] { model });
@@ -113,7 +113,7 @@ namespace Cash.Core.Tests.Services
         [ExpectedException(typeof(UnregisteredCacheTypeException))]
         public void GetArgumentsCacheKey_ThrowsAnException_WhenNoProviderIsRegistered()
         {
-            A.CallTo(() => CacheKeyRegistrationService.IsProviderRegistered(typeof(TestModelDefinition))).Returns(false);
+            A.CallTo(() => CacheKeyRegistrationService.IsFormatterRegistered(typeof(TestModelDefinition))).Returns(false);
 
             var model = new TestModelDefinition { Id = 100 };
             var result = CacheKeyGenerationService.GetArgumentsCacheKey(new object[] { model });

--- a/src/Cash.Core.Tests/Services/CacheKeyRegistrationServiceTests.cs
+++ b/src/Cash.Core.Tests/Services/CacheKeyRegistrationServiceTests.cs
@@ -25,7 +25,7 @@ namespace Cash.Core.Tests.Services
         [TestMethod]
         public void AddAndGetTypedCacheKeyProviders_PropertySetAndGet()
         {
-            Service.AddTypedCacheKeyProvider<int>(i => $"int_{i}");
+            Service.RegisterCacheKeyFormatter<int>(i => $"int_{i}");
 
             var targetProvider = Service.GetTypedCacheKeyProvider<int>();
             Assert.IsNotNull(targetProvider);
@@ -42,14 +42,14 @@ namespace Cash.Core.Tests.Services
         [ExpectedException(typeof(DuplicateCacheProviderRegistrationException))]
         public void AddTypedCacheKeyProvider_ThrowsAnExceptionWhenTheSameRegistrationTypeIsSet()
         {
-            Service.AddTypedCacheKeyProvider<int>(i => $"int_{i}");
-            Service.AddTypedCacheKeyProvider<int>(i => $"int2_{i}");
+            Service.RegisterCacheKeyFormatter<int>(i => $"int_{i}");
+            Service.RegisterCacheKeyFormatter<int>(i => $"int2_{i}");
         }
 
         [TestMethod]
         public void IsProviderRegistered_ReturnsTrue_WhenProviderIsRegistered()
         {
-            Service.AddTypedCacheKeyProvider<int>(i => $"int_{i}");
+            Service.RegisterCacheKeyFormatter<int>(i => $"int_{i}");
 
             var result = Service.IsProviderRegistered(typeof(int));
 
@@ -59,7 +59,7 @@ namespace Cash.Core.Tests.Services
         [TestMethod]
         public void IsProviderRegistered_ReturnsFals_WhenProviderIsNotRegistered()
         {
-            Service.AddTypedCacheKeyProvider<int>(i => $"int_{i}");
+            Service.RegisterCacheKeyFormatter<int>(i => $"int_{i}");
 
             var result = Service.IsProviderRegistered(typeof(string));
 

--- a/src/Cash.Core.Tests/Services/CacheKeyRegistrationServiceTests.cs
+++ b/src/Cash.Core.Tests/Services/CacheKeyRegistrationServiceTests.cs
@@ -27,7 +27,7 @@ namespace Cash.Core.Tests.Services
         {
             Service.RegisterCacheKeyFormatter<int>(i => $"int_{i}");
 
-            var targetProvider = Service.GetTypedCacheKeyProvider<int>();
+            var targetProvider = Service.GetCacheKeyFormatter<int>();
             Assert.IsNotNull(targetProvider);
         }
 
@@ -35,11 +35,11 @@ namespace Cash.Core.Tests.Services
         [ExpectedException(typeof(UnregisteredCacheTypeException))]
         public void GetTypedCacheKeyProvider_ThrowsAnExceptionWhenAProviderHasNotBeenRegistered()
         {
-            var targetProvider = Service.GetTypedCacheKeyProvider<string>();
+            var targetProvider = Service.GetCacheKeyFormatter<string>();
         }
 
         [TestMethod]
-        [ExpectedException(typeof(DuplicateCacheProviderRegistrationException))]
+        [ExpectedException(typeof(DuplicateCacheFormatterRegistrationException))]
         public void AddTypedCacheKeyProvider_ThrowsAnExceptionWhenTheSameRegistrationTypeIsSet()
         {
             Service.RegisterCacheKeyFormatter<int>(i => $"int_{i}");
@@ -51,7 +51,7 @@ namespace Cash.Core.Tests.Services
         {
             Service.RegisterCacheKeyFormatter<int>(i => $"int_{i}");
 
-            var result = Service.IsProviderRegistered(typeof(int));
+            var result = Service.IsFormatterRegistered(typeof(int));
 
             Assert.IsTrue(result);
         }
@@ -61,7 +61,7 @@ namespace Cash.Core.Tests.Services
         {
             Service.RegisterCacheKeyFormatter<int>(i => $"int_{i}");
 
-            var result = Service.IsProviderRegistered(typeof(string));
+            var result = Service.IsFormatterRegistered(typeof(string));
 
             Assert.IsFalse(result);
         }

--- a/src/Cash.Core/Cash.Core.csproj
+++ b/src/Cash.Core/Cash.Core.csproj
@@ -48,7 +48,7 @@
     <Compile Include="Attributes\CacheAttribute.cs" />
     <Compile Include="Enums\CacheItemPriority.cs" />
     <Compile Include="Enums\CacheKeyProviderExecutionOrder.cs" />
-    <Compile Include="Exceptions\DuplicateCacheProviderRegistrationException.cs" />
+    <Compile Include="Exceptions\DuplicateCacheFormatterRegistrationException.cs" />
     <Compile Include="Exceptions\UnregisteredCacheTypeException.cs" />
     <Compile Include="Extensions\CacheItemPriorityExtensions.cs" />
     <Compile Include="Interceptors\BaseCachingInterceptor.cs" />

--- a/src/Cash.Core/Exceptions/DuplicateCacheFormatterRegistrationException.cs
+++ b/src/Cash.Core/Exceptions/DuplicateCacheFormatterRegistrationException.cs
@@ -5,9 +5,9 @@ using System;
 
 namespace Cash.Core.Exceptions
 {
-    public class DuplicateCacheProviderRegistrationException : Exception
+    public class DuplicateCacheFormatterRegistrationException : Exception
     {
-        public DuplicateCacheProviderRegistrationException(Type type)
+        public DuplicateCacheFormatterRegistrationException(Type type)
             : base($"A registration for the type {type.Name} has already been registered with the system.")
         {
         }

--- a/src/Cash.Core/Providers/Base/BaseRegisteredCacheKeyProvider.cs
+++ b/src/Cash.Core/Providers/Base/BaseRegisteredCacheKeyProvider.cs
@@ -45,7 +45,7 @@ namespace Cash.Core.Providers.Base
 
         protected string GetCacheKeyValueRepresentation<TEntity>(TEntity item)
         {
-            var cacheKeyProvider = CacheKeyRegistrationService.GetTypedCacheKeyProvider<TEntity>();
+            var cacheKeyProvider = CacheKeyRegistrationService.GetCacheKeyFormatter<TEntity>();
             var value = cacheKeyProvider(item);
 
             return value;

--- a/src/Cash.Core/Providers/UserRegisteredCacheKeyProvider.cs
+++ b/src/Cash.Core/Providers/UserRegisteredCacheKeyProvider.cs
@@ -16,7 +16,7 @@ namespace Cash.Core.Providers
         public override bool IsValid(object parameter)
         {
             var type = parameter.GetType();
-            var output = CacheKeyRegistrationService.IsProviderRegistered(type);
+            var output = CacheKeyRegistrationService.IsFormatterRegistered(type);
             return output;
         }
     }

--- a/src/Cash.Core/Services/Base/ICacheKeyRegistrationService.cs
+++ b/src/Cash.Core/Services/Base/ICacheKeyRegistrationService.cs
@@ -13,7 +13,7 @@ namespace Cash.Core.Services
         /// </summary>
         /// <typeparam name="TEntity">The type of the registration entity.</typeparam>
         /// <param name="registrationPattern">The registration pattern.</param>
-        void AddTypedCacheKeyProvider<TEntity>(Expression<Func<TEntity, string>> registrationPattern);
+        void RegisterCacheKeyFormatter<TEntity>(Expression<Func<TEntity, string>> registrationPattern);
 
         /// <summary>
         ///     Gets the typed cache key provider.

--- a/src/Cash.Core/Services/Base/ICacheKeyRegistrationService.cs
+++ b/src/Cash.Core/Services/Base/ICacheKeyRegistrationService.cs
@@ -20,13 +20,13 @@ namespace Cash.Core.Services
         /// </summary>
         /// <typeparam name="TEntity">The type of the t entity.</typeparam>
         /// <returns>Expression&lt;Func&lt;TEntity, System.String&gt;&gt;.</returns>
-        Func<TEntity, string> GetTypedCacheKeyProvider<TEntity>();
+        Func<TEntity, string> GetCacheKeyFormatter<TEntity>();
 
         /// <summary>
         ///     Determines whether a typed cache key provider has been registered for a given type.
         /// </summary>
         /// <param name="type">The type to be checked</param>
         /// <returns><c>true</c> if [is provider registered] [the specified type]; otherwise, <c>false</c>.</returns>
-        bool IsProviderRegistered(Type type);
+        bool IsFormatterRegistered(Type type);
     }
 }

--- a/src/Cash.Core/Services/CacheKeyRegistrationService.cs
+++ b/src/Cash.Core/Services/CacheKeyRegistrationService.cs
@@ -14,8 +14,7 @@ namespace Cash.Core.Services
     /// </summary>
     public class CacheKeyRegistrationService : ICacheKeyRegistrationService
     {
-        private readonly IDictionary<Type, LambdaExpression> _cacheKeyProviders =
-            new Dictionary<Type, LambdaExpression>();
+        private readonly IDictionary<Type, LambdaExpression> _cacheKeyProviders = new Dictionary<Type, LambdaExpression>();
 
         /// <summary>
         ///     Adds the typed cache key provider.
@@ -23,7 +22,7 @@ namespace Cash.Core.Services
         /// <typeparam name="TEntity">The type of the registration entity.</typeparam>
         /// <param name="registrationPattern">The registration pattern.</param>
         /// <exception cref="DuplicateCacheProviderRegistrationException"></exception>
-        public void AddTypedCacheKeyProvider<TEntity>(Expression<Func<TEntity, string>> registrationPattern)
+        public void RegisterCacheKeyFormatter<TEntity>(Expression<Func<TEntity, string>> registrationPattern)
         {
             var targetType = typeof(TEntity);
 

--- a/src/Cash.Core/Services/CacheKeyRegistrationService.cs
+++ b/src/Cash.Core/Services/CacheKeyRegistrationService.cs
@@ -14,25 +14,25 @@ namespace Cash.Core.Services
     /// </summary>
     public class CacheKeyRegistrationService : ICacheKeyRegistrationService
     {
-        private readonly IDictionary<Type, LambdaExpression> _cacheKeyProviders = new Dictionary<Type, LambdaExpression>();
+        private readonly IDictionary<Type, LambdaExpression> _cacheKeyFormatters = new Dictionary<Type, LambdaExpression>();
 
         /// <summary>
         ///     Adds the typed cache key provider.
         /// </summary>
         /// <typeparam name="TEntity">The type of the registration entity.</typeparam>
         /// <param name="registrationPattern">The registration pattern.</param>
-        /// <exception cref="DuplicateCacheProviderRegistrationException"></exception>
+        /// <exception cref="DuplicateCacheFormatterRegistrationException"></exception>
         public void RegisterCacheKeyFormatter<TEntity>(Expression<Func<TEntity, string>> registrationPattern)
         {
             var targetType = typeof(TEntity);
 
-            if (_cacheKeyProviders.ContainsKey(targetType))
+            if (_cacheKeyFormatters.ContainsKey(targetType))
             {
-                throw new DuplicateCacheProviderRegistrationException(targetType);
+                throw new DuplicateCacheFormatterRegistrationException(targetType);
             }
 
             // using this for inspiration: http://stackoverflow.com/questions/16678057/list-of-expressionfunct-tproperty
-            _cacheKeyProviders.Add(targetType, registrationPattern);
+            _cacheKeyFormatters.Add(targetType, registrationPattern);
         }
 
         /// <summary>
@@ -40,13 +40,13 @@ namespace Cash.Core.Services
         /// </summary>
         /// <typeparam name="TEntity">The type of the t entity.</typeparam>
         /// <returns>Expression&lt;Func&lt;TEntity, System.String&gt;&gt;.</returns>
-        public Func<TEntity, string> GetTypedCacheKeyProvider<TEntity>()
+        public Func<TEntity, string> GetCacheKeyFormatter<TEntity>()
         {
             var targetType = typeof(TEntity);
 
-            if (_cacheKeyProviders.ContainsKey(targetType))
+            if (_cacheKeyFormatters.ContainsKey(targetType))
             {
-                var provider = _cacheKeyProviders[targetType];
+                var provider = _cacheKeyFormatters[targetType];
                 var expression = (Expression<Func<TEntity, string>>)provider;
                 return expression.Compile();
             }
@@ -54,9 +54,9 @@ namespace Cash.Core.Services
             throw new UnregisteredCacheTypeException(typeof(TEntity));
         }
 
-        public bool IsProviderRegistered(Type type)
+        public bool IsFormatterRegistered(Type type)
         {
-            var output = _cacheKeyProviders.ContainsKey(type);
+            var output = _cacheKeyFormatters.ContainsKey(type);
             return output;
         }
     }


### PR DESCRIPTION
The word 'Providers' was being used in the code base twice to indicate two different things:
- A user-defined registration that would convert a user-defined type into a cache string
- A system-defined object structure for handling different types and using them to create the correct cache string

Because of this, one of them had to go.  After consideration the naming of 'AddTypedCacheKeyProvider' seemed to be the most of of place, therefore it got renamed to 'RegisterCacheKeyFormatter'.  This is a much better representation of what this method does.  

I also updated other methods in that service to reflect the move away from the 'Provider' nomenclature.
