### PR TITLE
Implement a way to interact with the  SlidingExpiration feature

### DIFF
--- a/src/Cash.Core/CacheAttribute.cs
+++ b/src/Cash.Core/CacheAttribute.cs
@@ -46,20 +46,24 @@ namespace Cash.Core
             Measure = measure;
         }
 
+        /// <summary>
+        /// Constructs a <see cref="MemoryCacheEntryOptions"/> from the properties of this class.
+        /// </summary>
         public MemoryCacheEntryOptions GetCacheEntryOptions()
         {
+            // default to minutes
             TimeSpan ConvertDuration()
             {
                 switch (Measure)
                 {
                     case TimeMeasure.Seconds:
                         return TimeSpan.FromSeconds(Duration.Value);
-                    case TimeMeasure.Minutes:
-                        return TimeSpan.FromMinutes(Duration.Value);
                     case TimeMeasure.Hours:
                         return TimeSpan.FromHours(Duration.Value);
+                    // ReSharper disable once RedundantCaseLabel
+                    case TimeMeasure.Minutes:
                     default:
-                        throw new ArgumentOutOfRangeException();
+                        return TimeSpan.FromMinutes(Duration.Value);
                 }
             }
             
@@ -77,6 +81,9 @@ namespace Cash.Core
         }
     }
 
+    /// <summary>
+    /// Represents different increments of time measurement
+    /// </summary>
     public enum TimeMeasure
     {
         Seconds,

--- a/src/Cash.Core/CacheAttribute.cs
+++ b/src/Cash.Core/CacheAttribute.cs
@@ -13,22 +13,74 @@ namespace Cash.Core
     public class CacheAttribute : Attribute
     {
         /// <summary>
-        ///     Gets the priority at which something should be cached.
+        /// The priority at which something should be cached.
         /// </summary>
-        /// <value>The priority that should be used</value>
-        public CacheItemPriority Priority { get; private set; }
+        public CacheItemPriority Priority { get; }
 
         /// <summary>
-        ///     Initializes a new instance of the <see cref="CacheAttribute" /> class.
+        /// The maximum duration that the item should be cached. 
+        /// </summary>
+        public double? Duration { get; }
+
+        /// <summary>
+        /// The time measurement by which the <see cref="Duration"/> is applied.
+        /// </summary>
+        public TimeMeasure Measure { get; }
+
+        /// <summary>
+        ///  Initializes a new instance of the <see cref="CacheAttribute" /> class.
         /// </summary>
         /// <param name="priority">The <see cref="CacheItemPriority" /> priority that should be applied to this method's output.</param>
         public CacheAttribute(CacheItemPriority priority = CacheItemPriority.Normal)
         {
             Priority = priority;
         }
+        
+        /// <summary>
+        ///  Initializes a new instance of the <see cref="CacheAttribute" /> class.
+        /// </summary>
+        public CacheAttribute(double duration, TimeMeasure measure)
+        {
+            Priority = CacheItemPriority.Normal;
+            Duration = duration;
+            Measure = measure;
+        }
 
         public MemoryCacheEntryOptions GetCacheEntryOptions()
-            => new MemoryCacheEntryOptions()
-                .SetPriority(Priority);
+        {
+            TimeSpan ConvertDuration()
+            {
+                switch (Measure)
+                {
+                    case TimeMeasure.Seconds:
+                        return TimeSpan.FromSeconds(Duration.Value);
+                    case TimeMeasure.Minutes:
+                        return TimeSpan.FromMinutes(Duration.Value);
+                    case TimeMeasure.Hours:
+                        return TimeSpan.FromHours(Duration.Value);
+                    default:
+                        throw new ArgumentOutOfRangeException();
+                }
+            }
+            
+            var options = new MemoryCacheEntryOptions
+            {
+                Priority = Priority
+            };
+
+            if (Duration.HasValue)
+            {
+                options.SlidingExpiration = ConvertDuration();
+            }
+
+            return options;
+        }
+    }
+
+    public enum TimeMeasure
+    {
+        Seconds,
+        Minutes,
+        Hours
     }
 }


### PR DESCRIPTION
Per the definition of Microsoft's best practices outlined in #21, added the ability to define a SlidingExpiration interface through the `Cache` attribute.  